### PR TITLE
chore: install procps in docker image

### DIFF
--- a/infra/docker/docker-compose.dev.yml
+++ b/infra/docker/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
       - ../../:/app
     ports:
       - '3000:3000'
-    command: npm run start:dev
+    command: sh -c "apt-get update && apt-get install -y procps && npm run start:dev"
   mysql_test:
     container_name: 'mysql-db'
     image: mysql:8.0


### PR DESCRIPTION
The current docker image haven't procps package, which is needed for nest hot reload.